### PR TITLE
Prepare events store and fix idempotence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,8 @@ jobs:
           npm run lint
           npm run format
           mkdir -p dist
-          npx tsx src/main.ts "$(cat calendars.json)" > dist/calendar.ics
+          npx tsx src/update.ts "$(cat calendars.json)" > dist/calendar.json
+          npx tsx src/export.ts "dist/calendar.json" > dist/calendar.ics
 
   build:
     if: github.ref == 'refs/heads/main'

--- a/src/domain/CalendarEvent.spec.ts
+++ b/src/domain/CalendarEvent.spec.ts
@@ -25,6 +25,8 @@ const makeFull = () =>
     address: 'Address',
     geo: { lat: 86.5, lon: 10.6 },
     url: 'https://example.com',
+    createdAt: new Date('2025-05-06T12:23:34Z'),
+    updatedAt: new Date('2025-05-07T12:23:34Z'),
   });
 
 describe('CalendarEvent', () => {
@@ -44,5 +46,7 @@ describe('CalendarEvent', () => {
     expect(full.address).toBe('Address');
     expect(full.geo).toStrictEqual({ lat: 86.5, lon: 10.6 });
     expect(full.url).toBe('https://example.com');
+    expect(full.createdAt.toISOString()).toBe('2025-05-06T12:23:34.000Z');
+    expect(full.updatedAt.toISOString()).toBe('2025-05-07T12:23:34.000Z');
   });
 });

--- a/src/domain/CalendarEvent.ts
+++ b/src/domain/CalendarEvent.ts
@@ -9,6 +9,8 @@ export type CalendarEventBuilder = {
   address?: string;
   geo?: Geo;
   url?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
 };
 export type Geo = {
   lat: number;
@@ -34,6 +36,8 @@ export class CalendarEvent {
   readonly address?: string;
   readonly geo?: Geo;
   readonly url?: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
 
   private constructor(builder: CalendarEventBuilder) {
     this.#title = builder.title;
@@ -44,6 +48,8 @@ export class CalendarEvent {
     this.address = builder.address;
     this.geo = builder.geo;
     this.url = builder.url;
+    this.createdAt = builder.createdAt ?? new Date();
+    this.updatedAt = builder.updatedAt ?? new Date();
   }
 
   get fullTitle(): Name {
@@ -60,6 +66,8 @@ export class CalendarEvent {
       address: this.address,
       geo: this.geo,
       url: this.url,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     }
   }
 

--- a/src/domain/CalendarEvent.ts
+++ b/src/domain/CalendarEvent.ts
@@ -68,7 +68,7 @@ export class CalendarEvent {
       url: this.url,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
-    }
+    };
   }
 
   static of(builder: CalendarEventBuilder) {

--- a/src/domain/CalendarEvent.ts
+++ b/src/domain/CalendarEvent.ts
@@ -50,6 +50,19 @@ export class CalendarEvent {
     return Name.of(`[${this.#group.get}] ${this.#title.get}`);
   }
 
+  toBuilder(): CalendarEventBuilder {
+    return {
+      id: this.id,
+      title: this.#title,
+      group: this.#group,
+      date: this.date,
+      description: this.description,
+      address: this.address,
+      geo: this.geo,
+      url: this.url,
+    }
+  }
+
   static of(builder: CalendarEventBuilder) {
     return new CalendarEvent(builder);
   }

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import { toIcsExposedCalendar } from './primary/IcsExposedCalendar';
+import { deserialize, EventDto } from './primary/JsonCalendar';
 
 const storeFile = process.argv.at(2);
 
@@ -9,8 +10,8 @@ if (storeFile === undefined) {
   process.exit(1);
 }
 
-const calendar = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
-toIcsExposedCalendar(calendar)
+const calendar = JSON.parse(fs.readFileSync(storeFile, 'utf8')) as EventDto[];
+toIcsExposedCalendar(deserialize(calendar))
   .then((content) => {
     console.log(content);
     return process.exit(0);

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+
+import { toIcsExposedCalendar } from './primary/IcsExposedCalendar';
+
+const storeFile = process.argv.at(2);
+
+if (storeFile === undefined) {
+  console.error('Please add a store file as argument');
+  process.exit(1);
+}
+
+const calendar = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+toIcsExposedCalendar(calendar)
+  .then((content) => {
+    console.log(content);
+    return process.exit(0);
+  })
+  .catch((error) => {
+    console.error('Something goes wrong:', error);
+    return process.exit(1);
+  });

--- a/src/primary/IcsExposedCalendar.spec.ts
+++ b/src/primary/IcsExposedCalendar.spec.ts
@@ -59,4 +59,40 @@ describe('IcsExposedCalendar', () => {
     expect(exposedCalendar).toContain('DTSTART;VALUE=DATE:20240203');
     expect(exposedCalendar).toContain('DTEND;VALUE=DATE:20240204');
   });
+
+  it('should be idempotence', async () => {
+    const calendar = [
+      CalendarEvent.of({
+        id: 'IdA',
+        date: { start: { year: 2024, month: 2, day: 3 }, end: { year: 2024, month: 2, day: 3 } },
+        title: Name.of('Exposed title'),
+        group: Name.of('full'),
+        description: 'Description',
+        address: '22 Rue Delambre 75014 Paris',
+        createdAt: new Date('2025-05-06T12:23:34Z'),
+      }),
+    ];
+
+    const exposedCalendar1 = await toIcsExposedCalendar(calendar);
+    const exposedCalendar2 = await toIcsExposedCalendar(calendar);
+
+    expect(exposedCalendar1).toEqual(exposedCalendar2);
+  });
+
+  it('should use updatedAt as timestamp', async () => {
+    const calendar = [
+      CalendarEvent.of({
+        id: 'IdA',
+        date: { start: { year: 2024, month: 2, day: 3 }, end: { year: 2024, month: 2, day: 3 } },
+        title: Name.of('Exposed title'),
+        group: Name.of('full'),
+        createdAt: new Date('2025-05-06T12:23:34Z'),
+        updatedAt: new Date('2025-05-06T13:23:34Z'),
+      }),
+    ];
+
+    const exposedCalendar = await toIcsExposedCalendar(calendar);
+
+    expect(exposedCalendar).toContain('DTSTAMP:20250506T132334Z');
+  });
 });

--- a/src/primary/IcsExposedCalendar.ts
+++ b/src/primary/IcsExposedCalendar.ts
@@ -23,8 +23,9 @@ const convertDate = (date: Date | DateOnly, end: boolean): ics.DateTime => {
   return [date.year, date.month, date.day + (end ? 1 : 0)];
 };
 
-const toEventAttributes = (calendarEvent: CalendarEvent): EventAttributes => ({
+const toEventAttributes = (calendarEvent: CalendarEvent): EventAttributes & { timestamp?: ics.DateTime } => ({
   productId: 'lyontechhub/ics',
+  uid: calendarEvent.id,
   title: calendarEvent.fullTitle.get,
   start: convertDate(calendarEvent.date.start, false),
   end: convertDate(calendarEvent.date.end, true),
@@ -32,6 +33,9 @@ const toEventAttributes = (calendarEvent: CalendarEvent): EventAttributes => ({
   description: calendarEvent.description,
   geo: calendarEvent.geo,
   url: calendarEvent.url,
+  created: calendarEvent.createdAt ? convertDate(calendarEvent.createdAt, false) : undefined,
+  lastModified: calendarEvent.updatedAt ? convertDate(calendarEvent.updatedAt, false) : undefined,
+  timestamp: calendarEvent.createdAt ? convertDate(calendarEvent.updatedAt ?? calendarEvent.createdAt, false) : undefined,
 });
 
 const toEventAttributesList = (calendar: Calendar): EventAttributes[] => calendar.map(toEventAttributes);

--- a/src/primary/JsonCalendar.spec.ts
+++ b/src/primary/JsonCalendar.spec.ts
@@ -12,8 +12,8 @@ const sample = [
     title: Name.of('Exposed title'),
     group: Name.of('minimal'),
     description: 'blabal bla',
-    address: '15 rue de l\'arbre',
-    geo: {lat: 12.256, lon: 5.123},
+    address: "15 rue de l'arbre",
+    geo: { lat: 12.256, lon: 5.123 },
     url: 'https://example.com',
   }),
   CalendarEvent.of({
@@ -22,7 +22,7 @@ const sample = [
     title: Name.of('Exposed title'),
     group: Name.of('minimal'),
   }),
-]
+];
 
 describe('JsonCalendar', () => {
   it('should serialize and deserialize', async () => {

--- a/src/primary/JsonCalendar.spec.ts
+++ b/src/primary/JsonCalendar.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+import { CalendarEvent } from '../domain/CalendarEvent';
+import { Name } from '../domain/Name';
+
+import { deserialize, serialize } from './JsonCalendar';
+
+const sample = [
+  CalendarEvent.of({
+    id: 'IdA',
+    date: { start: new Date('2024-02-02T12:00:00.000Z'), end: new Date('2024-02-02T13:00:00.000Z') },
+    title: Name.of('Exposed title'),
+    group: Name.of('minimal'),
+    description: 'blabal bla',
+    address: '15 rue de l\'arbre',
+    geo: {lat: 12.256, lon: 5.123},
+    url: 'https://example.com',
+  }),
+  CalendarEvent.of({
+    id: 'IdB',
+    date: { start: { year: 2025, month: 5, day: 25 }, end: { year: 2025, month: 5, day: 26 } },
+    title: Name.of('Exposed title'),
+    group: Name.of('minimal'),
+  }),
+]
+
+describe('JsonCalendar', () => {
+  it('should serialize and deserialize', async () => {
+    const s1 = serialize(sample);
+    const d1 = deserialize(s1);
+    const s2 = serialize(d1);
+
+    expect(s1).toEqual(s2);
+    expect(JSON.stringify(sample)).toEqual(JSON.stringify(d1));
+  });
+});

--- a/src/primary/JsonCalendar.ts
+++ b/src/primary/JsonCalendar.ts
@@ -15,9 +15,9 @@ export interface EventDto {
   updatedAt?: string;
 }
 interface IntervalDto {
-  kind: string
-  start: string | DateOnly
-  end: string | DateOnly
+  kind: string;
+  start: string | DateOnly;
+  end: string | DateOnly;
 }
 
 function serializeInterval(value: Interval): IntervalDto {
@@ -25,10 +25,10 @@ function serializeInterval(value: Interval): IntervalDto {
     kind: value.start instanceof Date ? 'IntervalDateTime' : 'IntervalDateOnly',
     start: value.start instanceof Date ? value.start.toISOString() : value.start,
     end: value.end instanceof Date ? value.end.toISOString() : value.end,
-  }
+  };
 }
 function deserializeInterval(value: IntervalDto): Interval {
-  if(value.kind === 'IntervalDateOnly') {
+  if (value.kind === 'IntervalDateOnly') {
     return { start: value.start, end: value.end } as IntervalDateOnly;
   } else {
     return { start: new Date(value.start as string), end: new Date(value.end as string) } as IntervalDateTime;
@@ -36,8 +36,8 @@ function deserializeInterval(value: IntervalDto): Interval {
 }
 
 export function serialize(calendar: Calendar): EventDto[] {
-  return calendar.map(e => {
-    const builder = e.toBuilder()
+  return calendar.map((e) => {
+    const builder = e.toBuilder();
     return {
       id: e.id,
       title: builder.title.get,
@@ -49,11 +49,11 @@ export function serialize(calendar: Calendar): EventDto[] {
       url: builder.url,
       createdAt: builder.createdAt?.toISOString(),
       updatedAt: builder.updatedAt?.toISOString(),
-    }
-  })
+    };
+  });
 }
 export function deserialize(calendar: EventDto[]): Calendar {
-  return calendar.map(dto => {
+  return calendar.map((dto) => {
     return CalendarEvent.of({
       id: dto.id,
       title: Name.of(dto.title),
@@ -65,6 +65,6 @@ export function deserialize(calendar: EventDto[]): Calendar {
       url: dto.url,
       createdAt: dto.createdAt ? new Date(dto.createdAt) : undefined,
       updatedAt: dto.updatedAt ? new Date(dto.updatedAt) : undefined,
-    })
-  })
+    });
+  });
 }

--- a/src/primary/JsonCalendar.ts
+++ b/src/primary/JsonCalendar.ts
@@ -11,6 +11,8 @@ export interface EventDto {
   address?: string;
   geo?: Geo;
   url?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 interface IntervalDto {
   kind: string
@@ -45,6 +47,8 @@ export function serialize(calendar: Calendar): EventDto[] {
       address: builder.address,
       geo: builder.geo,
       url: builder.url,
+      createdAt: builder.createdAt?.toISOString(),
+      updatedAt: builder.updatedAt?.toISOString(),
     }
   })
 }
@@ -59,6 +63,8 @@ export function deserialize(calendar: EventDto[]): Calendar {
       address: dto.address,
       geo: dto.geo,
       url: dto.url,
+      createdAt: dto.createdAt ? new Date(dto.createdAt) : undefined,
+      updatedAt: dto.updatedAt ? new Date(dto.updatedAt) : undefined,
     })
   })
 }

--- a/src/primary/JsonCalendar.ts
+++ b/src/primary/JsonCalendar.ts
@@ -1,0 +1,64 @@
+import { Calendar } from '../domain/Calendar';
+import { CalendarEvent, DateOnly, Geo, Interval, IntervalDateOnly, IntervalDateTime } from '../domain/CalendarEvent';
+import { Name } from '../domain/Name';
+
+export interface EventDto {
+  id: string;
+  title: string;
+  group: string;
+  date: IntervalDto;
+  description?: string;
+  address?: string;
+  geo?: Geo;
+  url?: string;
+}
+interface IntervalDto {
+  kind: string
+  start: string | DateOnly
+  end: string | DateOnly
+}
+
+function serializeInterval(value: Interval): IntervalDto {
+  return {
+    kind: value.start instanceof Date ? 'IntervalDateTime' : 'IntervalDateOnly',
+    start: value.start instanceof Date ? value.start.toISOString() : value.start,
+    end: value.end instanceof Date ? value.end.toISOString() : value.end,
+  }
+}
+function deserializeInterval(value: IntervalDto): Interval {
+  if(value.kind === 'IntervalDateOnly') {
+    return { start: value.start, end: value.end } as IntervalDateOnly;
+  } else {
+    return { start: new Date(value.start as string), end: new Date(value.end as string) } as IntervalDateTime;
+  }
+}
+
+export function serialize(calendar: Calendar): EventDto[] {
+  return calendar.map(e => {
+    const builder = e.toBuilder()
+    return {
+      id: e.id,
+      title: builder.title.get,
+      group: builder.group.get,
+      date: serializeInterval(builder.date),
+      description: builder.description,
+      address: builder.address,
+      geo: builder.geo,
+      url: builder.url,
+    }
+  })
+}
+export function deserialize(calendar: EventDto[]): Calendar {
+  return calendar.map(dto => {
+    return CalendarEvent.of({
+      id: dto.id,
+      title: Name.of(dto.title),
+      group: Name.of(dto.group),
+      date: deserializeInterval(dto.date),
+      description: dto.description,
+      address: dto.address,
+      geo: dto.geo,
+      url: dto.url,
+    })
+  })
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,20 @@
+import { IcsCalendarRepository } from './secondary/IcsCalendarRepository';
+
+const config = process.argv.at(2);
+
+if (config === undefined) {
+  console.error('Please add a config as argument');
+  process.exit(1);
+}
+
+const icsCalendarRepository = new IcsCalendarRepository(JSON.parse(config));
+icsCalendarRepository
+  .get()
+  .then((events) => {
+    console.log(JSON.stringify(events));
+    return process.exit(0);
+  })
+  .catch((error) => {
+    console.error('Something goes wrong:', error);
+    return process.exit(1);
+  });

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,3 +1,4 @@
+import { serialize } from './primary/JsonCalendar';
 import { IcsCalendarRepository } from './secondary/IcsCalendarRepository';
 
 const config = process.argv.at(2);
@@ -11,7 +12,7 @@ const icsCalendarRepository = new IcsCalendarRepository(JSON.parse(config));
 icsCalendarRepository
   .get()
   .then((events) => {
-    console.log(JSON.stringify(events));
+    console.log(JSON.stringify(serialize(events)));
     return process.exit(0);
   })
   .catch((error) => {


### PR DESCRIPTION
L'id et le timestamp n'était pas passé en paramètre et donc généré à chaque fois.  
La commande main a été découpé en deux:
- update.ts récupère les données et mémorise dans un fichier json
- export.ts converti le json en ics

Le fichier json est exposé et donc pourra être récupérer pour avoir les précédents évènements.